### PR TITLE
Resolves #49

### DIFF
--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 pub struct Release {
-    // tag_name: String,
+    pub tag_name: String,
     pub assets: Vec<Asset>,
 }
 

--- a/src/sync/download.rs
+++ b/src/sync/download.rs
@@ -20,6 +20,7 @@ pub struct Downloader<'a> {
 pub struct DownloadInfo {
     pub archive_path: PathBuf,
     pub asset_name: String,
+    pub tag_name: String,
 }
 
 impl<'a> Downloader<'a> {
@@ -106,6 +107,7 @@ impl<'a> Downloader<'a> {
                 Ok(DownloadInfo {
                     archive_path,
                     asset_name: asset.name.clone(),
+                    tag_name: release.tag_name,
                 })
             }
         }

--- a/src/sync/progress.rs
+++ b/src/sync/progress.rs
@@ -25,8 +25,13 @@ impl SyncProgress {
         }
     }
 
-    fn fmt_prefix(&self, emoji: Emoji, tool_name: &str) -> String {
-        let aligned_tool = format!("{:width$}", tool_name, width = self.max_tool_size);
+    fn fmt_prefix(&self, emoji: Emoji, tool_name: &str, tag_name: &str) -> String {
+        let aligned_tool = format!(
+            "{:width$} {:<8}",
+            tool_name,
+            tag_name,
+            width = self.max_tool_size
+        );
 
         format!("{}{}", emoji, aligned_tool)
     }
@@ -37,7 +42,7 @@ impl SyncProgress {
         self.multi_progress.add(
             ProgressBar::new(100)
                 .with_style(message_style)
-                .with_prefix(self.fmt_prefix(PROCESS, tool_name)),
+                .with_prefix(self.fmt_prefix(PROCESS, tool_name, "")),
         )
     }
 
@@ -53,8 +58,8 @@ impl SyncProgress {
         pb.finish_and_clear()
     }
 
-    pub fn success(&self, pb: ProgressBar, tool_name: &str) {
-        pb.set_prefix(self.fmt_prefix(SUCCESS, tool_name));
+    pub fn success(&self, pb: ProgressBar, tool_name: &str, tag_name: &str) {
+        pb.set_prefix(self.fmt_prefix(SUCCESS, tool_name, tag_name));
 
         let success_msg = format!("{}", style("Completed!").bold().green());
         pb.set_message(success_msg);
@@ -62,7 +67,7 @@ impl SyncProgress {
     }
 
     pub fn failure(&self, pb: ProgressBar, tool_name: &str, err_msg: String) {
-        pb.set_prefix(self.fmt_prefix(FAILURE, tool_name));
+        pb.set_prefix(self.fmt_prefix(FAILURE, tool_name, ""));
 
         let failure_msg = format!("{}", style(err_msg).red());
         pb.set_message(failure_msg);


### PR DESCRIPTION
This resolves #49


I took a stab at implementing this but Im not sure if my approach is the right
way to go. Because the list of tools is already known before actually calling
the github api the length of these names is also known. This is not that case
with the `tag_name`. The tags from the example file are all less than 7 long but
that does not guarantee other repos.

I could try and check what tags are available for all tools before actually
downloading them. Can I get your input on this?


```bash
$ cargo run -- --config tools.toml sync
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/tool --config tools.toml sync`
✅  bat        v0.21.0  Completed!
✅  difftastic 0.34.0   Completed!
✅  exa        v0.10.1  Completed!
✅  fd         v8.4.0   Completed!
✅  ripgrep    13.0.0   Completed!
```
