### PR TITLE
Better CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: actions/cache@v3
-      name: Cache ./target
+      name: Cache cargo
       with:
         path: |
           ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
     - uses: actions/cache@v3
       name: Cache ./target
       with:
-        path: target
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target
         key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
 
     - name: Build


### PR DESCRIPTION
This PR caches more directories on CI. These new directories are based on the following suggestions:

* [How I speeded up my Rust builds on GitHub ~30 times](https://ectobit.com/blog/speed-up-github-actions-rust-pipelines/)
* [rust-cache Action](https://github.com/Swatinem/rust-cache)

The `rust-cache` explains some more details on why some directories should be cached and not others.

Probably in the future, we will use `rust-cache` directly. But for now, I believe it should be good enough to just cache extra few directories.

I've noticed that `cargo` spends lots of time downloading the registry and sometimes even fails with spurious network errors. I believe this caching should address this problem.
