### PR TITLE
[#57] Adds install command to install known tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,19 @@ jobs:
       run: cargo test --verbose
 
     - if: matrix.os != 'windows-latest'
+      name: "Integration test: [unix] [install ripgrep]"
+      env:
+          SYNC_DIR: "install-ripgrep"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+          mkdir $SYNC_DIR
+          cargo run -- --config=tests/$SYNC_DIR.toml install ripgrep
+
+          ls -l $SYNC_DIR
+
+          if [[ ! -x $SYNC_DIR/rg ]]; then echo "error on: rg"; false; fi
+
+    - if: matrix.os != 'windows-latest'
       name: "Integration test: [unix] [only-ripgrep]"
       env:
           SYNC_DIR: "only-ripgrep"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Install all the tools from config in a different location:
 tool --config=path/to/my/config.toml sync
 ```
 
+Install a tool that is hardcoded in the known tools list:
+
+```shell
+tool install ripgrep
+```
+
 Run `tool --help` for more details.
 
 > :octocat: If you hit the limit for downloading assets or want to download

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -20,4 +20,7 @@ pub enum Command {
 
     /// Generate a default .tools.toml file and prints it to std out
     DefaultConfig,
+
+    /// Install a tool if it is hardcoded into internal database
+    Install { name: String },
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use crate::err;
 use crate::model::asset_name::AssetName;
+use crate::model::tool::{ToolInfo, ToolInfoTag};
 
 /// Stores global information about the tool installation process and detailed
 /// info about installing each particular tool.
@@ -37,6 +38,23 @@ pub struct ConfigAsset {
 
     /// Name of the specific asset to download
     pub asset_name: AssetName,
+}
+
+impl From<ToolInfo> for ConfigAsset {
+    fn from(tool_info: ToolInfo) -> Self {
+        let tag = match tool_info.tag {
+            ToolInfoTag::Specific(version) => Some(version),
+            ToolInfoTag::Latest => None,
+        };
+
+        Self {
+            owner: Some(tool_info.owner),
+            repo: Some(tool_info.repo),
+            exe_name: Some(tool_info.exe_name),
+            tag,
+            asset_name: tool_info.asset_name,
+        }
+    }
 }
 
 impl Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,16 @@ mod model;
 mod sync;
 
 use std::collections::BTreeMap;
+use std::fmt::Write;
 use std::path::PathBuf;
 
 use clap::Parser;
 
 use crate::config::cli::{Cli, Command};
-use crate::config::schema::ConfigAsset;
+use crate::config::schema::{Config, ConfigAsset};
 use crate::config::template;
 use crate::config::toml;
-use crate::sync::db::lookup_tool;
+use crate::sync::db::{build_db, lookup_tool};
 use crate::sync::sync;
 
 const DEFAULT_CONFIG_PATH: &str = ".tool.toml";
@@ -23,6 +24,7 @@ pub fn run() {
     let config_path = resolve_config_path(cli.config.clone());
 
     match cli.command {
+        Command::DefaultConfig => generate_config(),
         Command::Sync => match toml::parse_file(&config_path) {
             Err(e) => {
                 err::abort_with(&format!(
@@ -31,20 +33,43 @@ pub fn run() {
                     e.display()
                 ));
             }
-            Ok(tool) => {
-                sync(tool);
+            Ok(config) => {
+                sync(config);
             }
         },
-        Command::DefaultConfig => generate_config(),
         Command::Install { name } => {
-            if let Some(tool_info) = lookup_tool(&name) {
-                if let Ok(mut tool) = toml::parse_file(&config_path) {
+            with_parsed_file(&config_path, |mut config| {
+                if let Some(tool_info) = lookup_tool(&name) {
                     let tool_btree: BTreeMap<String, ConfigAsset> =
                         BTreeMap::from([(name, tool_info.into())]);
-                    tool.tools = tool_btree;
-                    sync(tool);
-                }
-            }
+                    config.tools = tool_btree;
+                    sync(config);
+                } else {
+                    let mut exit_message: String =
+                        format!("Unknown tool: {}\nSupported tools:\n", name);
+                    for tool in build_db().keys().cloned().collect::<Vec<String>>() {
+                        if let Err(e) = writeln!(exit_message, "\t* {}", tool) {
+                            err::abort_suggest_issue(&format!("{}", e));
+                        };
+                    }
+                    err::abort_with(&exit_message);
+                };
+            });
+        }
+    }
+}
+
+fn with_parsed_file<F: FnOnce(Config)>(config_path: &PathBuf, on_success: F) {
+    match toml::parse_file(config_path) {
+        Ok(config) => {
+            on_success(config);
+        }
+        Err(e) => {
+            err::abort_with(&format!(
+                "Error parsing configuration at path {}: {}",
+                config_path.display(),
+                e.display()
+            ));
         }
     }
 }

--- a/tests/install-ripgrep.toml
+++ b/tests/install-ripgrep.toml
@@ -1,0 +1,1 @@
+store_directory = "install-ripgrep"


### PR DESCRIPTION
Resolves #57 

This pr adds an `isntall` subcommand that lets the user install any of the hardcoded tools. As a bonus it also implements the `From` trait to convert from `ToolInfo` To `ConfigAsset`.

### Additional tasks

- [x] Documentation for changes provided/changed
- [x] Tests added
