### PR TITLE
[#83] Create 'AssetError' and refactor 'select_asset' function to return it

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,6 @@ By default `tool-sync` reads configuration from `$HOME/.tool.toml` you can run `
 default-config` to print a default configuration example to std out. You can
 redirect this out put to a file like so `tool default-config >
 $HOME/.tool.toml`.
-TODO: create directory automatically, or prompt user to say yes?
-TODO: tools not added to $PATH automatically
-TODO: colorful output of ERROR
 
 You can also quickly copy the above configuration to the default path by running
 the following command (Unix-only):

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ store_directory = "~/.local/bin"
 By default `tool-sync` reads configuration from `$HOME/.tool.toml` you can run `tool
 default-config` to print a default configuration example to std out. You can
 redirect this out put to a file like so `tool default-config >
-$HOME/.tools.toml`.
+$HOME/.tool.toml`.
+TODO: create directory automatically, or prompt user to say yes?
+TODO: tools not added to $PATH automatically
+TODO: colorful output of ERROR
 
 You can also quickly copy the above configuration to the default path by running
 the following command (Unix-only):

--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -18,7 +18,7 @@ pub struct Asset {
 #[derive(Debug, PartialEq, Eq)]
 pub enum AssetError {
     /// Asset name of this OS is unknown
-    NameUnknown,
+    OsSelectorUnknown,
 
     /// Asset name is not in the fetched assets
     NotFound(String),
@@ -27,7 +27,7 @@ pub enum AssetError {
 impl Display for AssetError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NameUnknown => {
+            Self::OsSelectorUnknown => {
                 write!(
                     f,
                     "Unknown asset selector for OS: {}. Specify 'asset_name.your_os' in the cofig.",

--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::fmt::{Display, Formatter};
 
 #[derive(Deserialize, Debug)]
 pub struct Release {
@@ -11,4 +12,39 @@ pub struct Asset {
     pub id: u32,
     pub name: String,
     pub size: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AssetError {
+    /// Asset name of this OS is unknown
+    NameUnknown,
+
+    /// Asset name is not in the fetched assets
+    NotFound(String),
+}
+
+impl Display for AssetError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NameUnknown => {
+                write!(f, "Don't know the asset name for this OS: specify it explicitly in the config")
+            }
+            Self::NotFound(asset_name) => {
+                write!(f, "No asset matching name: {}", asset_name)
+            }
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_asset_error() {
+        let asset_name = "test_asset";
+        let error_str = AssetError::NotFound(asset_name.to_string()).to_string();
+        assert_ne!(error_str.find(asset_name), None);
+    }
 }

--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -1,5 +1,5 @@
-use std::env;
 use serde::Deserialize;
+use std::env;
 use std::fmt::{Display, Formatter};
 
 #[derive(Deserialize, Debug)]

--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -29,7 +29,8 @@ impl Display for AssetError {
             Self::NameUnknown => {
                 write!(
                     f,
-                    "Don't know the asset name for this OS: specify it explicitly in the config"
+                    "Unknown asset selector for OS: {}. Specify 'asset_name.your_os' in the cofig.",
+                    env::consts::OS
                 )
             }
             Self::NotFound(asset_name) => {

--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -1,3 +1,4 @@
+use std::env;
 use serde::Deserialize;
 use std::fmt::{Display, Formatter};
 
@@ -37,17 +38,5 @@ impl Display for AssetError {
                 write!(f, "No asset matching name: {}", asset_name)
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn display_asset_error() {
-        let asset_name = "test_asset";
-        let error_str = AssetError::NotFound(asset_name.to_string()).to_string();
-        assert_ne!(error_str.find(asset_name), None);
     }
 }

--- a/src/model/release.rs
+++ b/src/model/release.rs
@@ -7,7 +7,7 @@ pub struct Release {
     pub assets: Vec<Asset>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct Asset {
     pub id: u32,
     pub name: String,
@@ -27,7 +27,10 @@ impl Display for AssetError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NameUnknown => {
-                write!(f, "Don't know the asset name for this OS: specify it explicitly in the config")
+                write!(
+                    f,
+                    "Don't know the asset name for this OS: specify it explicitly in the config"
+                )
             }
             Self::NotFound(asset_name) => {
                 write!(f, "No asset matching name: {}", asset_name)
@@ -35,7 +38,6 @@ impl Display for AssetError {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -112,6 +112,51 @@ mod tests {
     use super::*;
 
     #[test]
+    fn asset_fount() {
+        let asset_name = "asset";
+
+        let tool_info = ToolInfo {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            exe_name: "exe".to_string(),
+            tag: ToolInfoTag::Latest,
+            asset_name: AssetName {
+                linux: Some(asset_name.to_string()),
+                macos: Some(asset_name.to_string()),
+                windows: Some(asset_name.to_string()),
+            },
+        };
+
+        let assets = vec![
+            Asset {
+                id: 1,
+                name: "1".to_string(),
+                size: 10,
+            },
+            Asset {
+                id: 2,
+                name: asset_name.to_string(),
+                size: 50,
+            },
+            Asset {
+                id: 3,
+                name: "3".to_string(),
+                size: 77,
+            },
+        ];
+
+        assert_eq!(
+            tool_info.select_asset(&assets),
+            Ok(Asset {
+                id: 2,
+                name: asset_name.to_string(),
+                size: 50
+            })
+        );
+    }
+
+
+    #[test]
     fn asset_not_found() {
         let asset_name = "asset";
 

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -70,6 +70,7 @@ pub struct ToolInfo {
 }
 
 impl ToolInfo {
+    /// Select an Asset from all Assets based on which Operating System is used
     pub fn select_asset(&self, assets: &[Asset]) -> Result<Asset, AssetError> {
         match self.asset_name.get_name_by_os() {
             None => Err(AssetError::NameUnknown),

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -155,7 +155,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn asset_not_found() {
         let asset_name = "asset";

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -195,4 +195,24 @@ mod tests {
             Err(AssetError::NotFound(asset_name.to_string()))
         );
     }
+
+    #[test]
+    fn asset_os_selector_unknown() {
+        let tool_info = ToolInfo {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            exe_name: "exe".to_string(),
+            tag: ToolInfoTag::Latest,
+            asset_name: AssetName {
+                linux: None,
+                macos: None,
+                windows: None,
+            },
+        };
+
+        assert_eq!(
+            tool_info.select_asset(&Vec::new()),
+            Err(AssetError::OsSelectorUnknown)
+        );
+    }
 }

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -109,16 +109,45 @@ pub struct ToolAsset {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     #[test]
-    fn display_os_asset_error() {
+    fn asset_not_found() {
+        let asset_name = "asset";
 
+        let tool_info = ToolInfo {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            exe_name: "exe".to_string(),
+            tag: ToolInfoTag::Latest,
+            asset_name: AssetName {
+                linux: Some(asset_name.to_string()),
+                macos: Some(asset_name.to_string()),
+                windows: Some(asset_name.to_string()),
+            },
+        };
+
+        let assets = vec![
+            Asset {
+                id: 1,
+                name: "1".to_string(),
+                size: 10,
+            },
+            Asset {
+                id: 2,
+                name: "2".to_string(),
+                size: 50,
+            },
+            Asset {
+                id: 3,
+                name: "3".to_string(),
+                size: 77,
+            },
+        ];
+
+        assert_eq!(
+            tool_info.select_asset(&assets),
+            Err(AssetError::NotFound(asset_name.to_string()))
+        );
     }
-
-    #[test]
-    fn display_notfound_asset_error() {
-
-    }
-
-
 }

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -73,7 +73,7 @@ impl ToolInfo {
     /// Select an Asset from all Assets based on which Operating System is used
     pub fn select_asset(&self, assets: &[Asset]) -> Result<Asset, AssetError> {
         match self.asset_name.get_name_by_os() {
-            None => Err(AssetError::NameUnknown),
+            None => Err(AssetError::OsSelectorUnknown),
             Some(asset_name) => {
                 let asset = assets.iter().find(|&asset| asset.name.contains(asset_name));
 

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -1,6 +1,7 @@
 use super::release::Asset;
 use crate::infra::client::Client;
 use crate::model::asset_name::AssetName;
+use crate::model::release::AssetError;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Tool {
@@ -69,16 +70,14 @@ pub struct ToolInfo {
 }
 
 impl ToolInfo {
-    pub fn select_asset(&self, assets: &[Asset]) -> Result<Asset, String> {
+    pub fn select_asset(&self, assets: &[Asset]) -> Result<Asset, AssetError> {
         match self.asset_name.get_name_by_os() {
-            None => Err(String::from(
-                "Don't know the asset name for this OS: specify it explicitly in the config",
-            )),
+            None => Err(AssetError::NameUnknown),
             Some(asset_name) => {
                 let asset = assets.iter().find(|&asset| asset.name.contains(asset_name));
 
                 match asset {
-                    None => Err(format!("No asset matching name: {}", asset_name)),
+                    None => Err(AssetError::NotFound(asset_name.to_owned())),
                     Some(asset) => Ok(asset.clone()),
                 }
             }
@@ -106,4 +105,20 @@ pub struct ToolAsset {
 
     /// GitHub API client that produces the stream for downloading the asset
     pub client: Client,
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn display_os_asset_error() {
+
+    }
+
+    #[test]
+    fn display_notfound_asset_error() {
+
+    }
+
+
 }

--- a/src/sync/prefetch.rs
+++ b/src/sync/prefetch.rs
@@ -124,8 +124,8 @@ fn prefetch_tool(
                     None
                 }
                 Ok(release) => match tool_info.select_asset(&release.assets) {
-                    Err(msg) => {
-                        prefetch_progress.unexpected_err_msg(tool_name, &msg);
+                    Err(err) => {
+                        prefetch_progress.unexpected_err_msg(tool_name, &err.to_string());
                         prefetch_progress.update_message(already_completed);
                         None
                     }


### PR DESCRIPTION
Resolves #83

Refactored `ToolInfo.select_asset(&assets)` to return a custom `AssetError` error instead of a string and added tests for the function.

The `AssetError` enum has two possible values:
- `NameUnknown`: this is when `AssetName` does not know what the asset name is for a specific OS the user uses.
- `NotFound`: this is when the `AssetName` is not in the `Assets` slice passed into the `select_asset(&assets)` method.

Implemented `std::fmt::Display` trait for `AssetError` and added tests for it.
 
### Additional tasks

- [x] Documentation for changes provided/changed
- [x] Tests added
