### PR TITLE
[#98] changed all formatting functions so they accept a type that implements Display

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -64,14 +64,14 @@ impl Config {
         let expanded_store_directory = shellexpand::full(&self.store_directory);
 
         let store_directory = match expanded_store_directory {
-            Err(e) => err::abort_with(&e),
+            Err(e) => err::abort_with(e),
             Ok(cow_path) => PathBuf::from(cow_path.into_owned()),
         };
 
         let has_store_directory = store_directory.as_path().is_dir();
 
         if !has_store_directory {
-            err::abort_with(&format!(
+            err::abort_with(format!(
                 "Specified directory for storing tools doesn't exist: {}",
                 store_directory.display()
             ));

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -64,7 +64,7 @@ impl Config {
         let expanded_store_directory = shellexpand::full(&self.store_directory);
 
         let store_directory = match expanded_store_directory {
-            Err(e) => err::abort_with(&e.to_string()),
+            Err(e) => err::abort_with(&e),
             Ok(cow_path) => PathBuf::from(cow_path.into_owned()),
         };
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -31,7 +31,7 @@ pub fn with_parsed_file<F: FnOnce(Config)>(config_path: PathBuf, on_success: F) 
             on_success(config);
         }
         Err(e) => {
-            err::abort_with(&format!(
+            err::abort_with(format!(
                 "Error parsing configuration at path {}: {}",
                 config_path.display(),
                 e

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -34,7 +34,7 @@ pub fn with_parsed_file<F: FnOnce(Config)>(config_path: PathBuf, on_success: F) 
             err::abort_with(&format!(
                 "Error parsing configuration at path {}: {}",
                 config_path.display(),
-                e.to_string()
+                e
             ));
         }
     }

--- a/src/infra/err.rs
+++ b/src/infra/err.rs
@@ -16,7 +16,7 @@ pub fn abort_with<Message: Display>(err_msg: &Message) -> ! {
 
 /// Print an error message, suggesting opening an issue and exit with code 1
 /// This function can take in any type that implements the [`Display`] trait
-pub fn abort_suggest_issue<Message: Display + ?Sized>(err_msg: &Message) -> ! {
+pub fn abort_suggest_issue<Message: Display>(err_msg: &Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
 

--- a/src/infra/err.rs
+++ b/src/infra/err.rs
@@ -3,7 +3,7 @@ use std::process;
 
 /// Print an error message and exit with code 1
 /// This function can take in any type that implements the [`Display`] trait
-pub fn abort_with<Message: Display>(err_msg: &Message) -> ! {
+pub fn abort_with<Message: Display>(err_msg: Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
 
@@ -16,7 +16,7 @@ pub fn abort_with<Message: Display>(err_msg: &Message) -> ! {
 
 /// Print an error message, suggesting opening an issue and exit with code 1
 /// This function can take in any type that implements the [`Display`] trait
-pub fn abort_suggest_issue<Message: Display>(err_msg: &Message) -> ! {
+pub fn abort_suggest_issue<Message: Display>(err_msg: Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
 
@@ -35,7 +35,7 @@ this issue:
 
 /// Print just the message and exit
 /// This function can take in any type that implements the [`Display`] trait
-pub fn abort<Message: Display>(err_msg: &Message) -> ! {
+pub fn abort<Message: Display>(err_msg: Message) -> ! {
     eprintln!("{}", err_msg);
     process::exit(1);
 }

--- a/src/infra/err.rs
+++ b/src/infra/err.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 use std::process;
 
 /// Print an error message and exit with code 1
+/// This function can take in any type that implements the [`Display`] trait
 pub fn abort_with<Message: Display>(err_msg: &Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
@@ -14,6 +15,7 @@ pub fn abort_with<Message: Display>(err_msg: &Message) -> ! {
 }
 
 /// Print an error message, suggesting opening an issue and exit with code 1
+/// This function can take in any type that implements the [`Display`] trait
 pub fn abort_suggest_issue<Message: Display + ?Sized>(err_msg: &Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
@@ -32,6 +34,7 @@ this issue:
 }
 
 /// Print just the message and exit
+/// This function can take in any type that implements the [`Display`] trait
 pub fn abort<Message: Display>(err_msg: &Message) -> ! {
     eprintln!("{}", err_msg);
     process::exit(1);

--- a/src/infra/err.rs
+++ b/src/infra/err.rs
@@ -1,7 +1,8 @@
+use std::fmt::Display;
 use std::process;
 
 /// Print an error message and exit with code 1
-pub fn abort_with(err_msg: &str) -> ! {
+pub fn abort_with<Message: Display>(err_msg: &Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
 
@@ -13,7 +14,7 @@ pub fn abort_with(err_msg: &str) -> ! {
 }
 
 /// Print an error message, suggesting opening an issue and exit with code 1
-pub fn abort_suggest_issue(err_msg: &str) -> ! {
+pub fn abort_suggest_issue<Message: Display + ?Sized>(err_msg: &Message) -> ! {
     eprintln!(
         r#"Aborting 'tool-sync' with error:
 
@@ -31,7 +32,7 @@ this issue:
 }
 
 /// Print just the message and exit
-pub fn abort(err_msg: &str) -> ! {
+pub fn abort<Message: Display>(err_msg: &Message) -> ! {
     eprintln!("{}", err_msg);
     process::exit(1);
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -27,6 +27,6 @@ Supported tools:
 {tools}"#
         );
 
-        err::abort(&exit_message);
+        err::abort(exit_message);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ fn resolve_config_path(config_path: Option<PathBuf>) -> PathBuf {
                 path
             }
             None => {
-                err::abort_suggest_issue("Unable to find $HOME directory");
+                err::abort_suggest_issue(&Box::new("Unable to find $HOME directory"));
             }
         },
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ fn resolve_config_path(config_path: Option<PathBuf>) -> PathBuf {
                 path
             }
             None => {
-                err::abort_suggest_issue(&Box::new("Unable to find $HOME directory"));
+                err::abort_suggest_issue(Box::new("Unable to find $HOME directory"));
             }
         },
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ fn resolve_config_path(config_path: Option<PathBuf>) -> PathBuf {
                 path
             }
             None => {
-                err::abort_suggest_issue(Box::new("Unable to find $HOME directory"));
+                err::abort_suggest_issue("Unable to find $HOME directory");
             }
         },
     }

--- a/src/sync/install.rs
+++ b/src/sync/install.rs
@@ -28,7 +28,7 @@ impl<'a> Installer<'a> {
         let tmp_dir = TempDir::new("tool-sync");
         match tmp_dir {
             Err(e) => {
-                err::abort_suggest_issue(&format!("Error creating temporary directory: {}", e));
+                err::abort_suggest_issue(format!("Error creating temporary directory: {}", e));
             }
             Ok(tmp_dir) => Installer {
                 store_directory,

--- a/src/sync/prefetch.rs
+++ b/src/sync/prefetch.rs
@@ -38,11 +38,13 @@ impl PrefetchProgress {
         }
     }
 
+    /// This method can take in any type that implements the [`Display`] trait
     fn expected_err_msg<Message: Display>(&self, tool_name: &str, msg: &Message) {
         let tool = format!("{}", style(tool_name).cyan().bold());
         self.pb.println(format!("{} {} {}", ERROR, tool, msg))
     }
 
+    /// This method can take in any type that implements the [`Display`] trait
     fn unexpected_err_msg<Message: Display>(&self, tool_name: &str, msg: &Message) {
         let tool = format!("{}", style(tool_name).cyan().bold());
         let err_msg = format!(

--- a/src/sync/prefetch.rs
+++ b/src/sync/prefetch.rs
@@ -108,7 +108,7 @@ fn prefetch_tool(
 
     match configure_tool(tool_name, config_asset) {
         Tool::Error(e) => {
-            prefetch_progress.expected_err_msg(tool_name, &e.to_string());
+            prefetch_progress.expected_err_msg(tool_name, &e);
             prefetch_progress.update_message(already_completed);
             None
         }
@@ -127,7 +127,7 @@ fn prefetch_tool(
                 }
                 Ok(release) => match tool_info.select_asset(&release.assets) {
                     Err(err) => {
-                        prefetch_progress.unexpected_err_msg(tool_name, &err.to_string());
+                        prefetch_progress.unexpected_err_msg(tool_name, &err);
                         prefetch_progress.update_message(already_completed);
                         None
                     }

--- a/src/sync/prefetch.rs
+++ b/src/sync/prefetch.rs
@@ -1,6 +1,8 @@
 use console::{style, Emoji};
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
+
 use std::collections::BTreeMap;
+use std::fmt::Display;
 
 use super::configure::configure_tool;
 use crate::config::schema::ConfigAsset;
@@ -36,12 +38,12 @@ impl PrefetchProgress {
         }
     }
 
-    fn expected_err_msg(&self, tool_name: &str, msg: &str) {
+    fn expected_err_msg<Message: Display>(&self, tool_name: &str, msg: &Message) {
         let tool = format!("{}", style(tool_name).cyan().bold());
         self.pb.println(format!("{} {} {}", ERROR, tool, msg))
     }
 
-    fn unexpected_err_msg(&self, tool_name: &str, msg: &str) {
+    fn unexpected_err_msg<Message: Display>(&self, tool_name: &str, msg: &Message) {
         let tool = format!("{}", style(tool_name).cyan().bold());
         let err_msg = format!(
             r#"{emoji} {tool} {msg}

--- a/src/sync/progress.rs
+++ b/src/sync/progress.rs
@@ -86,6 +86,7 @@ impl SyncProgress {
         pb.finish();
     }
 
+    /// This method can take in any type that implements the [`Display`] trait
     pub fn failure<Message: Display>(
         &self,
         pb: ProgressBar,

--- a/src/sync/progress.rs
+++ b/src/sync/progress.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use console::{style, Emoji};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
@@ -84,7 +86,13 @@ impl SyncProgress {
         pb.finish();
     }
 
-    pub fn failure(&self, pb: ProgressBar, tool_name: &str, tag: &str, err_msg: String) {
+    pub fn failure<Message: Display>(
+        &self,
+        pb: ProgressBar,
+        tool_name: &str,
+        tag: &str,
+        err_msg: Message,
+    ) {
         pb.set_prefix(self.fmt_prefix(FAILURE, tool_name, tag));
 
         let failure_msg = format!("{}", style(err_msg).red());


### PR DESCRIPTION
Resolves #98

This pr converts all functions that accept `&str` to print them out to stdout/err to accept any type that implements `Display` in its stead. This allows these functions to not care about the implementation of the actual print formatting and leaves that up to the implementation of whatever needs to be printed.

### Additional tasks

- [x] Documentation for changes provided/changed
- [ ] Tests added
