### PR TITLE
[#84] refactor of hardcoded tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ available [on GitHub][2].
 
 ## [Unreleased]
 
+### Fixed
+
+* [#84](https://github.com/chshersh/tool-sync/issues/84):
+  Refactor of hardcoded tools
+  (by [@MitchellBerend][MitchellBerend])
+
+
+
 ## [0.2.0] — 2022-09-20 🔃
 
 ### Added

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -12,7 +12,7 @@ pub fn lookup_tool(tool_name: &str) -> Option<ToolInfo> {
 }
 
 pub fn build_db() -> BTreeMap<String, ToolInfo> {
-    let mut tools = ToolBTreeMap::new();
+    let mut tools = BTreeMap::<&'static str, StaticToolInfo>::new();
 
     tools.insert(
         "bat",
@@ -24,8 +24,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "x86_64-apple-darwin",
             windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     tools.insert(
         "difftastic",
@@ -37,8 +36,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "x86_64-apple-darwin",
             windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     tools.insert(
         "exa",
@@ -50,8 +48,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "macos-x86_64",
             windows: NOT_SUPPORTED,
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     tools.insert(
         "fd",
@@ -63,8 +60,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "x86_64-apple-darwin",
             windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     tools.insert(
         "ripgrep",
@@ -76,8 +72,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "apple-darwin",
             windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     tools.insert(
         "tool-sync",
@@ -89,8 +84,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "x86_64-apple-darwin.tar.gz",
             windows: "x86_64-pc-windows-msvc.zip",
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     tools.insert(
         "github",
@@ -102,8 +96,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             macos: "macOS_amd64",
             windows: "windows_amd64.zip",
             tag: ToolInfoTag::Latest,
-        }
-        .into(),
+        },
     );
     //tools.insert(
     //    "tokei",
@@ -116,10 +109,13 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
     //        windows: "x86_64-pc-windows-msvc",
     //        tag: ToolInfoTag::Latest,
     //    }
-    //    .into(),
     //);
 
-    tools.into()
+    BTreeMap::from_iter(
+        tools
+            .into_iter()
+            .map(|(name, tool_info)| (name.to_owned(), tool_info.into())),
+    )
 }
 
 /// Format tool names of the database using a mutating formatting function
@@ -135,28 +131,6 @@ pub fn fmt_tool_names<F: FnMut(&String) -> String>(fmt_tool: F) -> String {
         .map(fmt_tool)
         .collect::<Vec<String>>()
         .join("\n")
-}
-
-struct ToolBTreeMap {
-    _inner_map: BTreeMap<String, ToolInfo>,
-}
-
-impl ToolBTreeMap {
-    fn new() -> Self {
-        Self {
-            _inner_map: BTreeMap::new(),
-        }
-    }
-
-    fn insert(&mut self, key: &'static str, value: ToolInfo) -> Option<ToolInfo> {
-        self._inner_map.insert(key.into(), value)
-    }
-}
-
-impl From<ToolBTreeMap> for BTreeMap<String, ToolInfo> {
-    fn from(tool_btree: ToolBTreeMap) -> Self {
-        tool_btree._inner_map
-    }
 }
 
 struct StaticToolInfo {
@@ -184,9 +158,9 @@ impl From<StaticToolInfo> for ToolInfo {
             repo: static_tool_info.repo.to_string(),
             exe_name: static_tool_info.exe_name.to_string(),
             asset_name: AssetName {
-                linux: from_supported_asset(static_tool_info.linux.to_string()),
-                macos: from_supported_asset(static_tool_info.macos.to_string()),
-                windows: from_supported_asset(static_tool_info.windows.to_string()),
+                linux: from_supported_asset(static_tool_info.linux),
+                macos: from_supported_asset(static_tool_info.macos),
+                windows: from_supported_asset(static_tool_info.windows),
             },
             tag: static_tool_info.tag,
         }
@@ -194,10 +168,10 @@ impl From<StaticToolInfo> for ToolInfo {
 }
 
 #[inline]
-fn from_supported_asset(asset_name: String) -> Option<String> {
+fn from_supported_asset(asset_name: &str) -> Option<String> {
     if asset_name == NOT_SUPPORTED {
         None
     } else {
-        Some(asset_name)
+        Some(asset_name.to_string())
     }
 }

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use crate::model::asset_name::AssetName;
 use crate::model::tool::{ToolInfo, ToolInfoTag};
 
+const NOT_SUPPORTED: &str = "NOT_SUPPORTED";
+
 /// Get info about known tools from a hardcoded database
 pub fn lookup_tool(tool_name: &str) -> Option<ToolInfo> {
     let mut known_db = build_db();
@@ -14,101 +16,94 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
 
     tools.insert(
         "bat".into(),
-        ToolInfo {
-            owner: "sharkdp".to_string(),
-            repo: "bat".to_string(),
-            exe_name: "bat".to_string(),
-            asset_name: AssetName {
-                linux: Some("x86_64-unknown-linux-musl".to_string()),
-                macos: Some("x86_64-apple-darwin".to_string()),
-                windows: Some("x86_64-pc-windows-msvc".to_string()),
-            },
+        StaticToolInfo {
+            owner: "sharkdp",
+            repo: "bat",
+            exe_name: "bat",
+            linux: "x86_64-unknown-linux-musl",
+            macos: "x86_64-apple-darwin",
+            windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     tools.insert(
         "difftastic".into(),
-        ToolInfo {
-            owner: "Wilfred".to_string(),
-            repo: "difftastic".to_string(),
-            exe_name: "difft".to_string(),
-            asset_name: AssetName {
-                linux: Some("x86_64-unknown-linux-gnu".to_string()),
-                macos: Some("x86_64-apple-darwin".to_string()),
-                windows: Some("x86_64-pc-windows-msvc".to_string()),
-            },
+        StaticToolInfo {
+            owner: "Wilfred",
+            repo: "difftastic",
+            exe_name: "difft",
+            linux: "x86_64-unknown-linux-gnu",
+            macos: "x86_64-apple-darwin",
+            windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     tools.insert(
         "exa".into(),
-        ToolInfo {
-            owner: "ogham".to_string(),
-            repo: "exa".to_string(),
-            exe_name: "exa".to_string(),
-            asset_name: AssetName {
-                linux: Some("linux-x86_64-musl".to_string()),
-                macos: Some("macos-x86_64".to_string()),
-                windows: None,
-            },
+        StaticToolInfo {
+            owner: "ogham",
+            repo: "exa",
+            exe_name: "exa",
+            linux: "linux-x86_64-musl",
+            macos: "macos-x86_64",
+            windows: NOT_SUPPORTED,
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     tools.insert(
         "fd".into(),
-        ToolInfo {
-            owner: "sharkdp".to_string(),
-            repo: "fd".to_string(),
-            exe_name: "fd".to_string(),
-            asset_name: AssetName {
-                linux: Some("x86_64-unknown-linux-musl".to_string()),
-                macos: Some("x86_64-apple-darwin".to_string()),
-                windows: Some("x86_64-pc-windows-msvc".to_string()),
-            },
+        StaticToolInfo {
+            owner: "sharkdp",
+            repo: "fd",
+            exe_name: "fd",
+            linux: "x86_64-unknown-linux-musl",
+            macos: "x86_64-apple-darwin",
+            windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     tools.insert(
         "ripgrep".into(),
-        ToolInfo {
-            owner: "BurntSushi".to_string(),
-            repo: "ripgrep".to_string(),
-            exe_name: "rg".to_string(),
-            asset_name: AssetName {
-                linux: Some("unknown-linux-musl".to_string()),
-                macos: Some("apple-darwin".to_string()),
-                windows: Some("x86_64-pc-windows-msvc".to_string()),
-            },
+        StaticToolInfo {
+            owner: "BurntSushi",
+            repo: "ripgrep",
+            exe_name: "rg",
+            linux: "unknown-linux-musl",
+            macos: "apple-darwin",
+            windows: "x86_64-pc-windows-msvc",
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     tools.insert(
         "tool-sync".into(),
-        ToolInfo {
-            owner: "chshersh".to_string(),
-            repo: "tool-sync".to_string(),
-            exe_name: "tool".to_string(),
-            asset_name: AssetName {
-                linux: Some("x86_64-unknown-linux-gnu.tar.gz".to_string()),
-                macos: Some("x86_64-apple-darwin.tar.gz".to_string()),
-                windows: Some("x86_64-pc-windows-msvc.zip".to_string()),
-            },
+        StaticToolInfo {
+            owner: "chshersh",
+            repo: "tool-sync",
+            exe_name: "tool",
+            linux: "x86_64-unknown-linux-gnu.tar.gz",
+            macos: "x86_64-apple-darwin.tar.gz",
+            windows: "x86_64-pc-windows-msvc.zip",
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     tools.insert(
         "github".into(),
-        ToolInfo {
-            owner: "cli".to_string(),
-            repo: "cli".to_string(),
-            exe_name: "gh".to_string(),
-            asset_name: AssetName {
-                linux: Some("linux_amd64.tar.gz".to_string()),
-                macos: Some("macOS_amd64".to_string()),
-                windows: Some("windows_amd64.zip".to_string()),
-            },
+        StaticToolInfo {
+            owner: "cli",
+            repo: "cli",
+            exe_name: "gh",
+            linux: "linux_amd64.tar.gz",
+            macos: "macOS_amd64",
+            windows: "windows_amd64.zip",
             tag: ToolInfoTag::Latest,
-        },
+        }
+        .into(),
     );
     // tools.insert("tokei", ToolInfo {
     //     owner: "XAMPPRocky".to_string(),
@@ -138,4 +133,71 @@ pub fn fmt_tool_names<F: FnMut(&String) -> String>(fmt_tool: F) -> String {
         .map(fmt_tool)
         .collect::<Vec<String>>()
         .join("\n")
+}
+
+struct StaticToolInfo {
+    /// Tool name
+    //pub name: &'static str,
+
+    /// GitHub repository author
+    pub owner: &'static str,
+
+    /// GitHub repository name
+    pub repo: &'static str,
+
+    /// Executable name inside the .tar.gz or .zip archive
+    pub exe_name: &'static str,
+
+    /// Version tag
+    pub tag: ToolInfoTag,
+
+    pub linux: &'static str,
+    pub macos: &'static str,
+    pub windows: &'static str,
+}
+
+//impl Into<ToolInfo> for StaticToolInfo {
+//    fn into(self) -> ToolInfo {
+//        ToolInfo {
+//            owner: self.owner.to_string(),
+//            repo: self.repo.to_string(),
+//            exe_name: self.exe_name.to_string(),
+//            tag: self.tag,
+//            asset_name: AssetName {
+//                linux: to_supported_asset(self.linux.to_string()),
+//                macos: to_supported_asset(self.macos.to_string()),
+//                windows: to_supported_asset(self.windows.to_string()),
+//            },
+//        }
+//    }
+//}
+
+//#[inline]
+//fn to_supported_asset(asset_name: String) -> Option<String> {
+//    if asset_name == NOT_SUPPORTED { None } else { Some(asset_name) }
+//}
+
+impl From<StaticToolInfo> for ToolInfo {
+    fn from(static_tool_info: StaticToolInfo) -> Self {
+        Self {
+            owner: static_tool_info.owner.to_string(),
+            repo: static_tool_info.repo.to_string(),
+            exe_name: static_tool_info.exe_name.to_string(),
+            asset_name: AssetName {
+                linux: from_supported_asset(static_tool_info.linux.to_string()),
+                macos: from_supported_asset(static_tool_info.macos.to_string()),
+                windows: from_supported_asset(static_tool_info.windows.to_string()),
+            },
+            tag: static_tool_info.tag,
+        }
+    }
+}
+
+#[inline]
+fn from_supported_asset(asset_name: String) -> Option<String> {
+    if asset_name == NOT_SUPPORTED {
+        None
+    } else {
+        Some(asset_name)
+    }
 }

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -11,11 +11,11 @@ pub fn lookup_tool(tool_name: &str) -> Option<ToolInfo> {
     known_db.remove(tool_name)
 }
 
-pub fn build_db() -> BTreeMap<String, ToolInfo> {
-    let mut tools: BTreeMap<String, ToolInfo> = BTreeMap::new();
+pub fn build_db() -> BTreeMap<&'static str, ToolInfo> {
+    let mut tools: BTreeMap<&'static str, ToolInfo> = BTreeMap::new();
 
     tools.insert(
-        "bat".into(),
+        "bat",
         StaticToolInfo {
             owner: "sharkdp",
             repo: "bat",
@@ -28,7 +28,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         .into(),
     );
     tools.insert(
-        "difftastic".into(),
+        "difftastic",
         StaticToolInfo {
             owner: "Wilfred",
             repo: "difftastic",
@@ -41,7 +41,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         .into(),
     );
     tools.insert(
-        "exa".into(),
+        "exa",
         StaticToolInfo {
             owner: "ogham",
             repo: "exa",
@@ -54,7 +54,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         .into(),
     );
     tools.insert(
-        "fd".into(),
+        "fd",
         StaticToolInfo {
             owner: "sharkdp",
             repo: "fd",
@@ -67,7 +67,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         .into(),
     );
     tools.insert(
-        "ripgrep".into(),
+        "ripgrep",
         StaticToolInfo {
             owner: "BurntSushi",
             repo: "ripgrep",
@@ -80,7 +80,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         .into(),
     );
     tools.insert(
-        "tool-sync".into(),
+        "tool-sync",
         StaticToolInfo {
             owner: "chshersh",
             repo: "tool-sync",
@@ -93,7 +93,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         .into(),
     );
     tools.insert(
-        "github".into(),
+        "github",
         StaticToolInfo {
             owner: "cli",
             repo: "cli",
@@ -105,18 +105,20 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         }
         .into(),
     );
-    // tools.insert("tokei", ToolInfo {
-    //     owner: "XAMPPRocky".to_string(),
-    //     repo: "tokei".to_string(),
-    //     exe_name: "tokei".to_string(),
-    //     asset_name: AssetName {
-    //         linux: Some("x86_64-unknown-linux-musl".to_string()),
-    //         macos: Some("apple-darwin".to_string()),
-    //         windows: Some("x86_64-pc-windows-msvc".to_string()),
-    //       }
-    //     tag: ToolInfoTag::Latest,
-    // }));
-    //
+    //tools.insert(
+    //    "tokei",
+    //    StaticToolInfo {
+    //        owner: "XAMPPRocky",
+    //        repo: "tokei",
+    //        exe_name: "tokei",
+    //        linux: "x86_64-unknown-linux-musl",
+    //        macos: "apple-darwin",
+    //        windows: "x86_64-pc-windows-msvc",
+    //        tag: ToolInfoTag::Latest,
+    //    }
+    //    .into(),
+    //);
+
     tools
 }
 
@@ -127,7 +129,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
 /// # [bat]
 /// # [exa]
 /// ```
-pub fn fmt_tool_names<F: FnMut(&String) -> String>(fmt_tool: F) -> String {
+pub fn fmt_tool_names<F: FnMut(&'static str) -> String>(fmt_tool: F) -> String {
     build_db()
         .keys()
         .map(fmt_tool)
@@ -136,9 +138,6 @@ pub fn fmt_tool_names<F: FnMut(&String) -> String>(fmt_tool: F) -> String {
 }
 
 struct StaticToolInfo {
-    /// Tool name
-    //pub name: &'static str,
-
     /// GitHub repository author
     pub owner: &'static str,
 

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -179,7 +179,7 @@ struct StaticToolInfo {
 
 impl From<StaticToolInfo> for ToolInfo {
     fn from(static_tool_info: StaticToolInfo) -> Self {
-        Self {
+        ToolInfo {
             owner: static_tool_info.owner.to_string(),
             repo: static_tool_info.repo.to_string(),
             exe_name: static_tool_info.exe_name.to_string(),

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -11,8 +11,9 @@ pub fn lookup_tool(tool_name: &str) -> Option<ToolInfo> {
     known_db.remove(tool_name)
 }
 
-pub fn build_db() -> BTreeMap<&'static str, ToolInfo> {
-    let mut tools: BTreeMap<&'static str, ToolInfo> = BTreeMap::new();
+pub fn build_db() -> BTreeMap<String, ToolInfo> {
+    //let mut tools: BTreeMap<&'static str, ToolInfo> = BTreeMap::new();
+    let mut tools = ToolBTreeMap::new();
 
     tools.insert(
         "bat",
@@ -119,7 +120,7 @@ pub fn build_db() -> BTreeMap<&'static str, ToolInfo> {
     //    .into(),
     //);
 
-    tools
+    tools.into()
 }
 
 /// Format tool names of the database using a mutating formatting function
@@ -129,12 +130,34 @@ pub fn build_db() -> BTreeMap<&'static str, ToolInfo> {
 /// # [bat]
 /// # [exa]
 /// ```
-pub fn fmt_tool_names<F: FnMut(&'static str) -> String>(fmt_tool: F) -> String {
+pub fn fmt_tool_names<F: FnMut(&String) -> String>(fmt_tool: F) -> String {
     build_db()
         .keys()
         .map(fmt_tool)
         .collect::<Vec<String>>()
         .join("\n")
+}
+
+struct ToolBTreeMap {
+    _inner_map: BTreeMap<String, ToolInfo>,
+}
+
+impl ToolBTreeMap {
+    fn new() -> Self {
+        Self {
+            _inner_map: BTreeMap::new(),
+        }
+    }
+
+    fn insert(&mut self, key: &'static str, value: ToolInfo) -> Option<ToolInfo> {
+        self._inner_map.insert(key.into(), value)
+    }
+}
+
+impl From<ToolBTreeMap> for BTreeMap<String, ToolInfo> {
+    fn from(tool_btree: ToolBTreeMap) -> Self {
+        tool_btree._inner_map
+    }
 }
 
 struct StaticToolInfo {

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -12,7 +12,6 @@ pub fn lookup_tool(tool_name: &str) -> Option<ToolInfo> {
 }
 
 pub fn build_db() -> BTreeMap<String, ToolInfo> {
-    //let mut tools: BTreeMap<&'static str, ToolInfo> = BTreeMap::new();
     let mut tools = ToolBTreeMap::new();
 
     tools.insert(
@@ -177,27 +176,6 @@ struct StaticToolInfo {
     pub macos: &'static str,
     pub windows: &'static str,
 }
-
-//impl Into<ToolInfo> for StaticToolInfo {
-//    fn into(self) -> ToolInfo {
-//        ToolInfo {
-//            owner: self.owner.to_string(),
-//            repo: self.repo.to_string(),
-//            exe_name: self.exe_name.to_string(),
-//            tag: self.tag,
-//            asset_name: AssetName {
-//                linux: to_supported_asset(self.linux.to_string()),
-//                macos: to_supported_asset(self.macos.to_string()),
-//                windows: to_supported_asset(self.windows.to_string()),
-//            },
-//        }
-//    }
-//}
-
-//#[inline]
-//fn to_supported_asset(asset_name: String) -> Option<String> {
-//    if asset_name == NOT_SUPPORTED { None } else { Some(asset_name) }
-//}
 
 impl From<StaticToolInfo> for ToolInfo {
     fn from(static_tool_info: StaticToolInfo) -> Self {


### PR DESCRIPTION
Resolves #84 

This pr aims to simplify the way tools are added so that there aren't any `into()` calls to convert from `&str` to `String`.

### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Remove `Into` or `From` implementation
