### PR TITLE
[#116] prevent sha from being included in asset name hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ available [on GitHub][2].
 
 ## [Unreleased]
 
+### Fixed
+
+* [#116](https://github.com/chshersh/tool-sync/issues/116):
+  Prevent sha from being included in asset name hits
+  (by [@MitchellBerend][MitchellBerend])
+
 ## [0.2.0] — 2022-09-20 🔃
 
 ### Added

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -78,7 +78,9 @@ impl ToolInfo {
             Some(asset_name) => {
                 let mut filtered_assets = assets
                     .iter()
-                    .filter(|&asset| asset.name.contains(asset_name) && !asset.name.contains("sha"))
+                    .filter(|&asset| {
+                        asset.name.contains(asset_name) && !asset.name.contains(".sha")
+                    })
                     .map(|asset| asset.to_owned())
                     .collect::<Vec<Asset>>();
                 match filtered_assets.len() {

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -78,7 +78,7 @@ impl ToolInfo {
             Some(asset_name) => {
                 let mut filtered_assets = assets
                     .iter()
-                    .filter(|&asset| asset.name.contains(asset_name))
+                    .filter(|&asset| asset.name.contains(asset_name) && !asset.name.contains("sha"))
                     .map(|asset| asset.to_owned())
                     .collect::<Vec<Asset>>();
                 match filtered_assets.len() {
@@ -202,6 +202,11 @@ mod tests {
             Asset {
                 id: 3,
                 name: "not a match".to_string(),
+                size: 77,
+            },
+            Asset {
+                id: 3,
+                name: "asset_1.sha256".to_string(),
                 size: 77,
             },
         ];


### PR DESCRIPTION
Resolves #116 
This pr adds filters out the `sha` substring in the asset name so it does not get trigger a `MultipleFound` error. It also augments a test to check this behaviour.

Thanks to @slyshykO for finding this bug and reporting it.

### Additional tasks

- [ ] Documentation for changes provided/changed
- [x] Tests added
