### PR TITLE
[#119] De-pluralize success message when only 1 tool is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ available [on GitHub][2].
 * [#84](https://github.com/chshersh/tool-sync/issues/84):
   Refactor of hardcoded tools
   (by [@MitchellBerend][MitchellBerend])
+* [#119](https://github.com/chshersh/tool-sync/issues/119):
+  De-pluralize success message when only 1 tool is installed
+  (by [@zixuanzhang-x][zixuanzhang-x])
 
 
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -107,6 +107,10 @@ pub fn sync_from_config_no_check(config: Config) {
         }
     }
 
+    summary_message(installed_tools, store_directory);
+}
+
+fn summary_message(installed_tools: u64, store_directory: PathBuf) {
     eprintln!(
         "{} Successfully installed {} {}!",
         DONE,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -107,7 +107,16 @@ pub fn sync_from_config_no_check(config: Config) {
         }
     }
 
-    eprintln!("{} Successfully installed {} tools!", DONE, installed_tools);
+    eprintln!(
+        "{} Successfully installed {} {}!",
+        DONE,
+        installed_tools,
+        if installed_tools == 1 {
+            "tool"
+        } else {
+            "tools"
+        }
+    );
     eprintln!(
         "{} Installation directory: {}",
         DIRECTORY,


### PR DESCRIPTION
Resolves #119 

<!--
Write description of your changes here
-->


### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
