### PR TITLE
[#109] Add `--path` option to the `default-config` command to print default config location instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ available [on GitHub][2].
 * [#111](https://github.com/chshersh/tool-sync/issues/111):
   Adds repo URLs to the output of `default-config` and `install` commands
   (by [@crudiedo][crudiedo])
+* [#109](https://github.com/chshersh/tool-sync/issues/109)
+  Adds a `--path` option to the `default-config` command to print
+  default config location intead
+  (by [@zixuanzhang-x][zixuanzhang-x])
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ Print the default config to stdout:
 tool default-config
 ```
 
+Print the default config location to stdout:
+
+```shell
+tool default-config --path
+```
+
 Run `tool --help` for more details.
 
 > :octocat: If you hit the limit for downloading assets or want to download

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -18,8 +18,12 @@ pub enum Command {
     /// Sync all tools specified in configuration file or the only one specified in the command line
     Sync { tool: Option<String> },
 
-    /// Generate a default .tool.toml file and prints it to std out
-    DefaultConfig,
+    /// Print a default .tool.toml configuration to std out
+    DefaultConfig {
+        /// Print the default config file location instead
+        #[clap(long)]
+        path: bool,
+    },
 
     /// Install a tool if it is hardcoded into internal database
     Install { name: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,10 @@ pub fn run() {
     let config_path = resolve_config_path(cli.config);
 
     match cli.command {
-        Command::DefaultConfig => config::template::generate_default_config(),
+        Command::DefaultConfig { path } => match path {
+            true => print_default_path(),
+            false => config::template::generate_default_config(),
+        },
         Command::Sync { tool } => sync::sync_from_path(config_path, tool),
         Command::Install { name } => install::install(config_path, name),
     }
@@ -29,16 +32,24 @@ const DEFAULT_CONFIG_PATH: &str = ".tool.toml";
 fn resolve_config_path(config_path: Option<PathBuf>) -> PathBuf {
     match config_path {
         Some(path) => path,
-        None => match dirs::home_dir() {
-            Some(home_path) => {
-                let mut path = PathBuf::new();
-                path.push(home_path);
-                path.push(DEFAULT_CONFIG_PATH);
-                path
-            }
-            None => {
-                err::abort_suggest_issue("Unable to find $HOME directory");
-            }
-        },
+        None => get_default_config_path(),
     }
+}
+
+fn get_default_config_path() -> PathBuf {
+    match dirs::home_dir() {
+        Some(home_path) => {
+            let mut path = PathBuf::new();
+            path.push(home_path);
+            path.push(DEFAULT_CONFIG_PATH);
+            path
+        }
+        None => {
+            err::abort_suggest_issue("Unable to find $HOME directory");
+        }
+    }
+}
+
+fn print_default_path() {
+    println!("{}", get_default_config_path().display());
 }


### PR DESCRIPTION
Resolves #109 

### Additional tasks

- [x] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
