### PR TITLE
[#108] Check prefetched `tool_assets` is not empty before passing it to `SyncProgress::new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ available [on GitHub][2].
 * [#119](https://github.com/chshersh/tool-sync/issues/119):
   De-pluralize success message when only 1 tool is installed
   (by [@zixuanzhang-x][zixuanzhang-x])
-
+* [#108](https://github.com/chshersh/tool-sync/issues/108):
+  Check prefetched `tool_assets` is not empty before passing
+  it to `SyncProgress::new`
+  (by [@zixuanzhang-x][zixuanzhang-x])
 
 
 ## [0.2.0] — 2022-09-20 🔃

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -85,7 +85,12 @@ pub fn sync_single_tool(mut config: Config, name: String, asset: ConfigAsset) {
 /// Like `sync_from_config` but expects non-empty list of tools
 pub fn sync_from_config_no_check(config: Config) {
     let store_directory = config.ensure_store_directory();
+
     let tool_assets = prefetch(config.tools);
+    if tool_assets.is_empty() {
+        empty_prefetched_tool_assets_message();
+        return;
+    }
 
     let tool_pairs = tool_assets
         .iter()
@@ -126,4 +131,11 @@ fn summary_message(installed_tools: u64, store_directory: PathBuf) {
         DIRECTORY,
         store_directory.display()
     );
+}
+
+fn empty_prefetched_tool_assets_message() {
+    eprintln!(
+        r"No tools are required to sync: configuration is empty 
+or encountered error prefetching tools."
+    )
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -135,7 +135,6 @@ fn summary_message(installed_tools: u64, store_directory: PathBuf) {
 
 fn empty_prefetched_tool_assets_message() {
     eprintln!(
-        r"No tools are required to sync: configuration is empty 
-or encountered error prefetching tools."
+        r"Nothing to sync or encountered multiple errors prefetching tools."
     )
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -134,7 +134,5 @@ fn summary_message(installed_tools: u64, store_directory: PathBuf) {
 }
 
 fn empty_prefetched_tool_assets_message() {
-    eprintln!(
-        r"Nothing to sync or encountered multiple errors prefetching tools."
-    )
+    eprintln!(r"Nothing to sync or encountered multiple errors prefetching tools.")
 }


### PR DESCRIPTION
Resolves #108

### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
