### PR TITLE
[#128] Uses RepoError::NotFound when fetch_release_info returns 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ available [on GitHub][2].
   default config location intead
   (by [@zixuanzhang-x][zixuanzhang-x])
 * [#128](https://github.com/chshersh/tool-sync/issues/128)
-  Adds new error message RepoError::NotFound when fetch_release_info 
+  Adds new error message RepoError::NotFound when fetch_release_info
   returns 404
   (by [@crudiedo][crudiedo])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ available [on GitHub][2].
   Adds a `--path` option to the `default-config` command to print
   default config location intead
   (by [@zixuanzhang-x][zixuanzhang-x])
+* [#128](https://github.com/chshersh/tool-sync/issues/128)
+  Adds new error message RepoError::NotFound when fetch_release_info 
+  returns 404
+  (by [@crudiedo][crudiedo])
 
 ### Fixed
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 pub mod asset_name;
 pub mod os;
 pub mod release;
+pub mod repo;
 pub mod tool;

--- a/src/model/repo.rs
+++ b/src/model/repo.rs
@@ -1,0 +1,28 @@
+use crate::model::tool::LATEST_VERSION;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RepoError {
+    /// Either repository or tag is not found due to misconfiguration
+    NotFound {
+        owner: String,
+        repo: String,
+        tag: String,
+    },
+}
+
+impl Display for RepoError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RepoError::NotFound { owner, repo, tag } => match tag {
+                _ if tag == LATEST_VERSION => {
+                    write!(f, "The {owner}/{repo} doesn't exist or has no releases.")
+                }
+                _ => write!(
+                    f,
+                    "The {owner}/{repo} doesn't exist or {tag} was not found."
+                ),
+            },
+        }
+    }
+}

--- a/src/model/repo.rs
+++ b/src/model/repo.rs
@@ -1,4 +1,4 @@
-use crate::model::tool::LATEST_VERSION;
+use crate::model::tool::ToolInfoTag;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -7,7 +7,7 @@ pub enum RepoError {
     NotFound {
         owner: String,
         repo: String,
-        tag: String,
+        tag: ToolInfoTag,
     },
 }
 
@@ -15,12 +15,13 @@ impl Display for RepoError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             RepoError::NotFound { owner, repo, tag } => match tag {
-                _ if tag == LATEST_VERSION => {
+                ToolInfoTag::Latest => {
                     write!(f, "The {owner}/{repo} doesn't exist or has no releases.")
                 }
                 _ => write!(
                     f,
-                    "The {owner}/{repo} doesn't exist or {tag} was not found."
+                    "The {owner}/{repo} doesn't exist or {tag} was not found.",
+                    tag = tag.to_str_version()
                 ),
             },
         }

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -40,7 +40,7 @@ pub enum ToolInfoTag {
     Specific(String),
 }
 
-pub const LATEST_VERSION: &str = "latest";
+const LATEST_VERSION: &str = "latest";
 
 impl ToolInfoTag {
     pub fn to_str_version(&self) -> String {

--- a/src/model/tool.rs
+++ b/src/model/tool.rs
@@ -40,7 +40,7 @@ pub enum ToolInfoTag {
     Specific(String),
 }
 
-const LATEST_VERSION: &str = "latest";
+pub const LATEST_VERSION: &str = "latest";
 
 impl ToolInfoTag {
     pub fn to_str_version(&self) -> String {

--- a/src/sync/prefetch.rs
+++ b/src/sync/prefetch.rs
@@ -140,7 +140,7 @@ fn prefetch_tool(
                             RepoError::NotFound {
                                 owner: tool_info.owner,
                                 repo: tool_info.repo,
-                                tag: tool_info.tag.to_str_version(),
+                                tag: tool_info.tag,
                             },
                         );
                     } else {

--- a/src/sync/prefetch.rs
+++ b/src/sync/prefetch.rs
@@ -8,6 +8,7 @@ use super::configure::configure_tool;
 use crate::config::schema::ConfigAsset;
 use crate::infra::client::Client;
 use crate::model::release::AssetError;
+use crate::model::repo::RepoError;
 use crate::model::tool::{Tool, ToolAsset};
 
 const PREFETCH: Emoji<'_, '_> = Emoji("🔄 ", "-> ");
@@ -133,7 +134,18 @@ fn prefetch_tool(
 
             match client.fetch_release_info() {
                 Err(e) => {
-                    prefetch_progress.unexpected_err_msg(tool_name, e);
+                    if let Some(ureq::Error::Status(404, _)) = e.downcast_ref::<ureq::Error>() {
+                        prefetch_progress.unexpected_err_msg(
+                            tool_name,
+                            RepoError::NotFound {
+                                owner: tool_info.owner,
+                                repo: tool_info.repo,
+                                tag: tool_info.tag.to_str_version(),
+                            },
+                        );
+                    } else {
+                        prefetch_progress.unexpected_err_msg(tool_name, e);
+                    }
                     // do some other processing
                     prefetch_progress.update_message(already_completed);
                     None


### PR DESCRIPTION
<!-- PR title template: [#ISSUE_NUMBER] <short description>
     Example:           [#42] Solve problem X
-->

Resolves #128

This PR adds a new error `RepoError::NotFound` and uses it when fetch_release_info  returns 404.

The error message depends on the tag, and could be either 
❌  **bottom** The clementtsang/bottomx doesn't exist or tags/0.66.3 was not found.

or

❌  **bottom** The clementtsang/bottomx doesn't exist or has no releases.

if the tag is latest.

### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
