### PR TITLE
[#136] Upgrade clap to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,12 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,26 +63,24 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -99,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -215,12 +207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,16 +230,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -589,12 +565,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "tool"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "3.2.17", features = ["derive"] }
+clap = { version = "4.0.15", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 ureq = { version = "2.5.0", features = ["json"] }
 zip = { version = "0.6.2", default-features = false, features = ["deflate"] }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -3,16 +3,16 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
-#[clap(author="Dmitrii Kovanikov <kovanikov@gmail.com>", version, about="A CLI tool to manage other CLI tools", long_about = None)]
+#[command(author="Dmitrii Kovanikov <kovanikov@gmail.com>", version, about="A CLI tool to manage other CLI tools", long_about = None)]
 pub struct Cli {
     /// Sets a path to a configuration file (default: $HOME/.tool.toml)
-    #[clap(short, long, value_name = "FILE")]
+    #[arg(short, long, value_name = "FILE")]
     pub config: Option<PathBuf>,
 
-    #[clap(short, long, value_name = "uri")]
+    #[arg(short, long, value_name = "uri")]
     pub proxy: Option<String>,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: Command,
 }
 
@@ -24,7 +24,7 @@ pub enum Command {
     /// Print a default .tool.toml configuration to std out
     DefaultConfig {
         /// Print the default config file location instead
-        #[clap(long)]
+        #[arg(long)]
         path: bool,
     },
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -109,10 +109,8 @@ fn decode_config(toml: Value, proxy: Option<String>) -> Result<Config, DecodeErr
         },
     )?;
 
-    let proxy: Option<String> = proxy.or_else(|| match toml.get("proxy") {
-        Some(p) => Some(p.as_str().unwrap_or("").into()),
-        None => None,
-    });
+    let proxy: Option<String> =
+        proxy.or_else(|| toml.get("proxy").map(|p| p.as_str().unwrap_or("").into()));
 
     let mut tools = BTreeMap::new();
 
@@ -253,14 +251,10 @@ mod tests {
     #[test]
     fn test_parse_file_error() {
         let test_config_path = PathBuf::from("src/main.rs");
-        match parse_file(&test_config_path, None) {
-            Ok(_) => {
-                assert!(false, "Unexpected succces")
-            }
-            Err(_) => {
-                assert!(true, "Exepected a parsing error")
-            }
-        };
+        assert!(
+            parse_file(&test_config_path, None).is_err(),
+            "Expected a parsing error, parsing succeeded instead"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolves #136.

This PR upgrades the `clap` dependency to `4.0`.

I can also upgrade the other dependencies in the same PR itself, since they only involve modifications to the `Cargo.toml` and `Cargo.lock` files, `clippy` lints and tests pass without any code modifications.


### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [ ] Updated CHANGELOG.md

---

PS: I'm unsure if this requires a changelog entry, I can add one if required.
