### PR TITLE
add shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
           if [[ ! -x $SYNC_DIR/just      ]]; then echo "error on: just";      false; fi
           if [[ ! -x $SYNC_DIR/k9s       ]]; then echo "error on: k9s";       false; fi
           if [[ ! -x $SYNC_DIR/procs     ]]; then echo "error on: procs";     false; fi
+          if [[ ! -x $SYNC_DIR/shellcheck ]]; then echo "error on: shellcheck; false; fi
 
           # disabled because of: https://github.com/alexcrichton/tar-rs/issues/295
           # if [[ ! -x $SYNC_DIR/tokei ]]; then echo "error on: tokei"; false; fi
@@ -179,6 +180,9 @@ jobs:
           }
           if (!(Test-Path $env:SYNC_DIR\procs.exe)) {
               throw 'error on procs.exe'
+          }
+          if (!(Test-Path $env:SYNC_DIR\shellcheck.exe)) {
+              throw 'error on shellcheck.exe'
           }
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           if [[ ! -x $SYNC_DIR/just      ]]; then echo "error on: just";      false; fi
           if [[ ! -x $SYNC_DIR/k9s       ]]; then echo "error on: k9s";       false; fi
           if [[ ! -x $SYNC_DIR/procs     ]]; then echo "error on: procs";     false; fi
-          if [[ ! -x $SYNC_DIR/shellcheck ]]; then echo "error on: shellcheck; false; fi
+          if [[ ! -x $SYNC_DIR/shellcheck ]]; then echo "error on: shellcheck"; false; fi
 
           # disabled because of: https://github.com/alexcrichton/tar-rs/issues/295
           # if [[ ! -x $SYNC_DIR/tokei ]]; then echo "error on: tokei"; false; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ available [on GitHub][2].
   Supports casey/just, dalance/procs, derailed/k9s, and
   sharkdp/hyperfine natively.
   (by [@hdhoang][hdhoang])
+* [#153](https://github.com/chshersh/tool-sync/issues/153)
+  Supports `tar.xz` assets, and koalaman/shellcheck
+  (by [@hdhoang][hdhoang])
 
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06754c4acf47d49c727d5665ca9fb828851cda315ed3bd51edd148ef78a8772"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +336,12 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "proc-macro-error"
@@ -640,6 +657,7 @@ dependencies = [
  "tempdir",
  "toml",
  "ureq",
+ "xz2",
  "zip",
 ]
 
@@ -883,6 +901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ shellexpand = "2.1.2"
 tar = "0.4.38"
 tempdir = "0.3.7"
 toml = "0.5.9"
+xz2 = { version = "0.1", default-features = false }

--- a/src/sync/archive.rs
+++ b/src/sync/archive.rs
@@ -1,6 +1,7 @@
 use flate2::read::GzDecoder;
 use std::fmt::{Display, Formatter};
 use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::model::asset_name::mk_exe_name;
@@ -60,6 +61,14 @@ impl<'a> Archive<'a> {
                 archive_type: ArchiveType::TarBall(tar_gz_dir),
             });
         };
+        if let Some(tar_xz_dir) = asset_name.strip_suffix(".tar.xz") {
+            return Some(Archive {
+                archive_path,
+                tmp_dir,
+                exe_name,
+                archive_type: ArchiveType::TarBall(tar_xz_dir),
+            });
+        };
         if let Some(zip_dir) = asset_name.strip_suffix(".zip") {
             return Some(Archive {
                 archive_path,
@@ -97,7 +106,7 @@ impl<'a> Archive<'a> {
 fn unpack_tar(tar_path: &PathBuf, tmp_dir: &Path) -> Result<(), std::io::Error> {
     // unpack tar_path to tmp_dir
     let tar_file = File::open(tar_path)?;
-    let tar_decoder = GzDecoder::new(tar_file);
+    let tar_decoder: Box<dyn Read> = Box::new(GzDecoder::new(tar_file));
     let mut archive = tar::Archive::new(tar_decoder);
     archive.unpack(tmp_dir)
 }

--- a/src/sync/archive.rs
+++ b/src/sync/archive.rs
@@ -44,38 +44,33 @@ impl<'a> Archive<'a> {
         exe_name: &'a str,
         asset_name: &'a str,
     ) -> Option<Archive<'a>> {
-        let tar_gz_dir = asset_name.strip_suffix(".tar.gz");
-
-        match tar_gz_dir {
-            Some(tar_gz_dir) => Some(Archive {
+        if let Some(exe_name) = asset_name.strip_suffix(".exe") {
+            return Some(Archive {
+                archive_path,
+                tmp_dir,
+                exe_name,
+                archive_type: ArchiveType::Exe(asset_name),
+            });
+        };
+        if let Some(tar_gz_dir) = asset_name.strip_suffix(".tar.gz") {
+            return Some(Archive {
                 archive_path,
                 tmp_dir,
                 exe_name,
                 archive_type: ArchiveType::TarBall(tar_gz_dir),
-            }),
-            None => {
-                let zip_dir = asset_name.strip_suffix(".zip");
-
-                match zip_dir {
-                    Some(zip_dir) => Some(Archive {
-                        archive_path,
-                        tmp_dir,
-                        exe_name,
-                        archive_type: ArchiveType::Zip(zip_dir),
-                    }),
-                    None => {
-                        let exe_file = asset_name.strip_suffix(".exe");
-
-                        exe_file.map(|_| Archive {
-                            archive_path,
-                            tmp_dir,
-                            exe_name,
-                            archive_type: ArchiveType::Exe(asset_name),
-                        })
-                    }
-                }
-            }
+            });
+        };
+        if let Some(zip_dir) = asset_name.strip_suffix(".zip") {
+            return Some(Archive {
+                archive_path,
+                tmp_dir,
+                tool_tag,
+                exe_name,
+                archive_type: ArchiveType::Zip(zip_dir),
+            });
         }
+
+        None
     }
 
     /// Unpack archive and return path to the executable tool

--- a/src/sync/archive.rs
+++ b/src/sync/archive.rs
@@ -16,7 +16,7 @@ pub struct Archive<'a> {
 enum ArchiveType<'a> {
     Exe(&'a str),
     Zip(&'a str),
-    TarGz(&'a str),
+    TarBall(&'a str),
 }
 
 pub enum UnpackError {
@@ -51,7 +51,7 @@ impl<'a> Archive<'a> {
                 archive_path,
                 tmp_dir,
                 exe_name,
-                archive_type: ArchiveType::TarGz(tar_gz_dir),
+                archive_type: ArchiveType::TarBall(tar_gz_dir),
             }),
             None => {
                 let zip_dir = asset_name.strip_suffix(".zip");
@@ -85,7 +85,7 @@ impl<'a> Archive<'a> {
             ArchiveType::Exe(exe_file) => Ok(PathBuf::from(exe_file)),
 
             // unpack .tar.gz archive
-            ArchiveType::TarGz(asset_name) => {
+            ArchiveType::TarBall(asset_name) => {
                 unpack_tar(self.archive_path, self.tmp_dir).map_err(UnpackError::IOError)?;
                 find_path_to_exe(self.archive_path, self.tmp_dir, self.exe_name, asset_name)
             }

--- a/src/sync/archive.rs
+++ b/src/sync/archive.rs
@@ -140,7 +140,7 @@ fn unpack_tar(tar_path: &PathBuf, tmp_dir: &Path) -> Result<(), IoError> {
 }
 
 fn unpack_zip(zip_path: &PathBuf, tmp_dir: &Path) -> Result<(), UnpackError> {
-    let zip_archive_file = File::open(&zip_path).map_err(UnpackError::IOError)?;
+    let zip_archive_file = File::open(zip_path).map_err(UnpackError::IOError)?;
 
     let mut archive = zip::ZipArchive::new(zip_archive_file).map_err(UnpackError::ZipError)?;
 

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -123,6 +123,18 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
         },
     );
     tools.insert(
+        "shellcheck",
+        StaticToolInfo {
+            owner: "koalaman",
+            repo: "shellcheck",
+            exe_name: "shellcheck",
+            linux: "linux.x86_64.tar",
+            macos: "darwin.x86_64",
+            windows: "zip",
+            tag: ToolInfoTag::Latest,
+        },
+    );
+    tools.insert(
         "tool-sync",
         StaticToolInfo {
             owner: "chshersh",

--- a/src/sync/install.rs
+++ b/src/sync/install.rs
@@ -71,10 +71,12 @@ impl<'a> Installer<'a> {
         };
 
         let download_info = downloader.download(self.tmp_dir.path())?;
+        let tool_tag = format!("{}-{}", &tool_asset.tool_name, &tool_asset.tag);
 
         let archive = Archive::from(
             &download_info.archive_path,
             self.tmp_dir.path(),
+            &tool_tag,
             &tool_asset.exe_name,
             &tool_asset.asset.name,
         );

--- a/tests/default-config.toml
+++ b/tests/default-config.toml
@@ -19,6 +19,7 @@
 # [k9s]        # https://github.com/derailed/k9s
 # [procs]      # https://github.com/dalance/procs
 # [ripgrep]    # https://github.com/BurntSushi/ripgrep
+# [shellcheck] # https://github.com/koalaman/shellcheck
 # [tool-sync]  # https://github.com/chshersh/tool-sync
 #
 # You can configure the installation of any tool by specifying corresponding options:

--- a/tests/sync-full.toml
+++ b/tests/sync-full.toml
@@ -13,6 +13,7 @@ store_directory = "sync-full"
 [just]
 [k9s]
 [procs]
+[shellcheck]
 
 #disabled because of: https://github.com/alexcrichton/tar-rs/issues/295
 # [tokei]


### PR DESCRIPTION

Resolves #146

For unsupported tar compressions, i made a string-based `io::Error`. I tried adding an `AssetError` variant for clarity, but constructing it in `archive.rs` proved much difficult. But it shouldn't be reachable because of `Archive::from` anyhow.

I added an early `$name-$tag` string because threading `ToolAsset` fields through the function added many `&str` parameters, which then get combined at the leaf `exe_paths`.
### Additional tasks

- [ ] Documentation for changes provided/changed
- [x] Tests added
- [x] Updated CHANGELOG.md
