### PR TITLE
[#138] Properly scope path to exe file under temp directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,21 @@ jobs:
               throw 'error on rg.exe'
           }
 
+    - if: matrix.os == 'windows-latest'
+      name: "Integration test: [windows] [sync-marksman]"
+      env:
+          SYNC_DIR: "sync-marksman"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+          mkdir $env:SYNC_DIR
+          cargo run -- --config="tests\$env:SYNC_DIR.toml" sync
+
+          ls -l $env:SYNC_DIR
+
+          if (!(Test-Path $env:SYNC_DIR\marksman.exe)) {
+              throw 'error on marksman.exe'
+          }
+
     - if: matrix.os != 'windows-latest'
       name: "Integration test: [unix] [sync-full]"
       env:

--- a/src/sync/archive.rs
+++ b/src/sync/archive.rs
@@ -82,7 +82,9 @@ impl<'a> Archive<'a> {
     pub fn unpack(&self) -> Result<PathBuf, UnpackError> {
         match self.archive_type {
             // already .exe file without archive (on Windows): no need to unpack
-            ArchiveType::Exe(exe_file) => Ok(PathBuf::from(exe_file)),
+            ArchiveType::Exe(exe_file) => {
+                Ok([self.tmp_dir, Path::new(exe_file)].into_iter().collect())
+            }
 
             // unpack .tar.gz archive
             ArchiveType::TarGz(asset_name) => {

--- a/tests/sync-marksman.toml
+++ b/tests/sync-marksman.toml
@@ -1,0 +1,6 @@
+store_directory = "sync-marksman"
+
+[marksman]
+owner = 'artempyanykh'
+repo = 'marksman'
+asset_name.windows = 'marksman.exe'


### PR DESCRIPTION
A top-level `.exe` file is passed through to `copy_file` without unpacking an archive, which is correct. However, the file was not correctly referred to under the temp directory, meaning we could not find the file to copy.

Resolves #138

### Additional tasks

- [ ] Documentation for changes provided/changed
- [x] Tests added
- [ ] Updated CHANGELOG.md
