### PR TITLE
db: update k9s artifact name for 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ available [on GitHub][2].
 * [#133](https://github.com/chshersh/tool-sync/issues/133)
   Added shell completion
   (by [@MitchellBerend][MitchellBerend])
-* [#147](https://github.com/chshersh/tool-sync/issues/147)
+* [#147](https://github.com/chshersh/tool-sync/issues/147) [#160](https://github.com/chshersh/tool-sync/issues/160)
   Supports casey/just, dalance/procs, derailed/k9s, and
   sharkdp/hyperfine natively.
   (by [@hdhoang][hdhoang])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ available [on GitHub][2].
 * [#133](https://github.com/chshersh/tool-sync/issues/133)
   Added shell completion
   (by [@MitchellBerend][MitchellBerend])
-* [#147](https://github.com/chshersh/tool-sync/issues/147) [#160](https://github.com/chshersh/tool-sync/issues/160)
+* [#147](https://github.com/chshersh/tool-sync/issues/147), [#160](https://github.com/chshersh/tool-sync/issues/160)
   Supports casey/just, dalance/procs, derailed/k9s, and
   sharkdp/hyperfine natively.
   (by [@hdhoang][hdhoang])

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -92,7 +92,7 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             owner: "derailed",
             repo: "k9s",
             exe_name: "k9s",
-            linux: "Linux_x86_64",
+            linux: "Linux_amd64",
             macos: "Darwin_x86_64",
             windows: "Windows_x86_64",
             tag: ToolInfoTag::Latest,

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -93,8 +93,8 @@ pub fn build_db() -> BTreeMap<String, ToolInfo> {
             repo: "k9s",
             exe_name: "k9s",
             linux: "Linux_amd64",
-            macos: "Darwin_x86_64",
-            windows: "Windows_x86_64",
+            macos: "Darwin_amd64",
+            windows: "Windows_amd64",
             tag: ToolInfoTag::Latest,
         },
     );


### PR DESCRIPTION
from derailed/k9s#1910

This will break installing older versions, so users must apply different config if they wish.

### Additional tasks

- [ ] Documentation for changes provided/changed
- [ ] Tests added
- [x] Updated CHANGELOG.md
